### PR TITLE
Fix comments count when --all is set

### DIFF
--- a/aur-comment-fetch
+++ b/aur-comment-fetch
@@ -73,8 +73,8 @@ def main(package,get_all,number,reverse_order):
             .format(package,BASE_URL+package))
         return
     else:
-        print('\033[35m\nLast {1} comments for package "{0}"{3}:\n full info at {2}\n\033[0m'
-            .format(package,number,BASE_URL+package,' (most recent last)' if reverse_order else ''))
+        print('\033[35m\n{4} {1} comments for package "{0}"{3}:\n full info at {2}\n\033[0m'
+            .format(package,len(comments),BASE_URL+package,' (most recent last)' if reverse_order else '','All' if get_all else 'Last'))
     for comment in (reversed(comments) if reverse_order else comments):
         print('\033[33m{0}: {1}\033[0m'.format(comment.timestamp,comment.author))
         print(textwrap.fill(comment.content,initial_indent='  ',subsequent_indent='  '))


### PR DESCRIPTION
When --all was set, the output was always (no matter what the actual
comment count was):

"Last 5 comments for package.."

Now the output is:

"All 16 comments for package.."
